### PR TITLE
support Recording

### DIFF
--- a/BeaconScanner/Base.lproj/MainMenu.xib
+++ b/BeaconScanner/Base.lproj/MainMenu.xib
@@ -1,8 +1,9 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="10117" systemVersion="15E65" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="11542" systemVersion="16B2555" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="10117"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="11542"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="HGAppDelegate">
@@ -48,6 +49,12 @@
                     <modifierMask key="keyEquivalentModifierMask"/>
                     <menu key="submenu" title="BeaconScanner" systemMenu="apple" id="uQy-DD-JDr">
                         <items>
+                            <menuItem title="Record" id="dZL-xp-pIH" userLabel="Record">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <connections>
+                                    <action selector="toggleRecord:" target="nF1-6k-907" id="vTP-f5-z5z"/>
+                                </connections>
+                            </menuItem>
                             <menuItem title="About BeaconScanner" id="5kV-Vb-QxS">
                                 <modifierMask key="keyEquivalentModifierMask"/>
                                 <connections>
@@ -704,7 +711,7 @@
                         <rect key="frame" x="-1" y="61" width="782" height="304"/>
                         <clipView key="contentView" id="nH9-IB-6pL">
                             <rect key="frame" x="1" y="0.0" width="780" height="303"/>
-                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                            <autoresizingMask key="autoresizingMask"/>
                             <subviews>
                                 <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" alternatingRowBackgroundColors="YES" columnSelection="YES" multipleSelection="NO" autosaveColumns="NO" headerView="1nI-Er-1Q8" id="AH2-px-RsF">
                                     <rect key="frame" x="0.0" y="0.0" width="780" height="280"/>
@@ -811,7 +818,6 @@
                                     </connections>
                                 </tableView>
                             </subviews>
-                            <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
                         </clipView>
                         <scroller key="horizontalScroller" hidden="YES" verticalHuggingPriority="750" horizontal="YES" id="WbE-Lt-SFB">
                             <rect key="frame" x="1" y="287" width="780" height="16"/>

--- a/BeaconScanner/HGBeaconViewController.m
+++ b/BeaconScanner/HGBeaconViewController.m
@@ -9,8 +9,8 @@
 #import "HGBeaconScanner.h"
 #import "HGBeacon.h"
 #import "ReactiveCocoa/ReactiveCocoa.h"
-#import "BlocksKit.h"
-#import "EXTScope.h"
+#import <BlocksKit/BlocksKit.h>
+#import <libextobjc/EXTScope.h>
 #import "HGBeaconHistory.h"
 #import "HGBluetoothState.h"
 #define HGBeaconTimeToLiveInterval 15
@@ -18,8 +18,23 @@
 @property (strong) RACSignal *housekeepingSignal;
 @property (strong) HGBeaconHistory *beaconHistory;
 @property (strong) HGBeacon *lastSelectedBeacon;
+@property BOOL recordBeacons;
 @end
 @implementation HGBeaconViewController
+
+
+- (IBAction)toggleRecord:(id)sender {
+    _recordBeacons = _recordBeacons ? FALSE : TRUE;
+    NSMenuItem *menuItem = (NSMenuItem*) sender;
+    NSString * newLabel = @"";
+    if (_recordBeacons) {
+        newLabel = @"Stop Recording";
+    } else {
+        newLabel = @"Recording";
+    }
+    [menuItem setTitle:newLabel];
+        
+}
 
 - (void) awakeFromNib {
     [self.tableView setAllowsEmptySelection:YES];
@@ -67,8 +82,8 @@
                     if (age > HGBeaconTimeToLiveInterval) {
                         NSUInteger index = 0;
                         for (HGBeacon *beacon in self.beacons) {
-                            if ([beacon isEqualToBeacon:candidateBeacon]) {
-                                [self removeObjectFromBeaconsAtIndex:index];
+                            if ([beacon isEqualToBeacon:candidateBeacon] && !_recordBeacons) {
+                               [self removeObjectFromBeaconsAtIndex:index];
                                 didChange = YES;
                                 break;
                             }

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -52,13 +52,15 @@ PODS:
     - ReactiveCocoa/Core
 
 DEPENDENCIES:
-  - BlocksKit (~> 2.2.5)
+  - BlocksKit
   - libextobjc
-  - ReactiveCocoa (~> 2.1)
+  - ReactiveCocoa
 
 SPEC CHECKSUMS:
   BlocksKit: 7f422b971407001178d181a43b99014ea2591fe6
   libextobjc: f2802d4262f6885570df9799747409ceb1de602c
-  ReactiveCocoa: fbe689fe218063b7bbed41032912c9ca4fdbe172
+  ReactiveCocoa: 81ee2fb7df2dfc6bd52b5d70473662195e20ca7d
 
-COCOAPODS: 0.36.1
+PODFILE CHECKSUM: 1ed3d7ebe15a03726069be1da715cce97033d967
+
+COCOAPODS: 1.1.1


### PR DESCRIPTION
Updates:
  * Cocoapods
  * imports to use `<>`  - as of recent cocoapod update

Adds:
  * Menu Entry `Recording` - once enabled, beacons won't be removed from tableview.

it is usefull if you drive arround with a laptop and just wan't to collect uuid's/major's/minor's